### PR TITLE
Excludes null passed where it's not awaited

### DIFF
--- a/CPCache/Classes/CFXCache.m
+++ b/CPCache/Classes/CFXCache.m
@@ -244,7 +244,7 @@ static dispatch_semaphore_t _globalLock;
 }
 
 - (BOOL)moveItemAtURLToTrash:(NSURL *)itemURL {
-    if (![[NSFileManager defaultManager] fileExistsAtPath:[itemURL path]]){
+    if (!itemURL || ![[NSFileManager defaultManager] fileExistsAtPath:[itemURL path]]){
         return NO;
     }
     NSError *error = nil;


### PR DESCRIPTION
Adds additional check to prevent passing nil to -[NSFileManager fileExistsAtPath:] awaiting not nil parameter.
Static analyzer is out friend!